### PR TITLE
Support recursive search with flag `-r`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ wget -O ~/.config/ranger/plugins/ranger_fzf_filter.py https://raw.githubusercont
 Command:
 
 - `:fzf_filter [query]`: filtering files with fzf, see this [search syntax](https://github.com/junegunn/fzf#search-syntax)
+- `:fzf_filter -r [query]`: filter through all files recursively by unfolding all subfolders
 
 
 
@@ -37,6 +38,7 @@ Add a binding to your `~/.config/ranger/rc.conf` file to quickly use `:fzf_filte
 
 ```
 map f console fzf_filter%space
+map F console fzf_filter%space-r%space
 ```
 
 

--- a/command.py
+++ b/command.py
@@ -8,7 +8,7 @@ class fzf_filter(ranger.api.commands.Command):
     :fzf_filter <query>
 
     Flags:
-    -r   Filter through all subfolders recursively
+    -r   filter through all files recursively by unfolding all subfolders
 
     Filter with fzf
     """

--- a/command.py
+++ b/command.py
@@ -7,16 +7,31 @@ class fzf_filter(ranger.api.commands.Command):
     """
     :fzf_filter <query>
 
+    Flags:
+    -r   Filter through all subfolders recursively
+
     Filter with fzf
     """
 
+    RECURSIVE_FILTER = 'r'
+
+    def __init__(self, *args, **kwargs):
+        super(fzf_filter, self).__init__(*args, **kwargs)
+        self.flags, self.rest = self.parse_flags()
+
     def execute(self):
+        if self.RECURSIVE_FILTER in self.flags:
+            self.fm.execute_console('flat -1')
+
         self.fm.thisdir.__dict__['fzf_filter'] = self._build_filter()
         self.fm.thisdir.refilter()
         if self.quickly_executed:
             self.fm.open_console(self.line)
 
     def cancel(self):
+        if self.RECURSIVE_FILTER in self.flags:
+            self.fm.execute_console('flat 0')
+
         self.fm.thisdir.__dict__['fzf_filter'] = None
         self.fm.thisdir.refilter()
 
@@ -25,6 +40,6 @@ class fzf_filter(ranger.api.commands.Command):
 
     def _build_filter(self):
         directory = self.fm.thisdir.path
-        source = [i.basename for i in self.fm.thisdir.files_all]
-        query = ' '.join(self.args[1:])
+        source = [i.relative_path for i in self.fm.thisdir.files_all]
+        query = ' '.join(self.rest)
         return FzfFilter(directory, source, query)

--- a/filter.py
+++ b/filter.py
@@ -16,6 +16,4 @@ class FzfFilter:
         self.result = stdout.decode('utf-8').strip().splitlines()
 
     def __call__(self, fobj):
-        if os.path.dirname(fobj.path) != self.directory:
-            return True
-        return fobj.basename in self.result
+        return fobj.relative_path in self.result


### PR DESCRIPTION
**Feature Updates**
1. If `-r` flag turns on, run `flat -1` first before doing `fzf` search and run `flat 0` when cancelling the command. This allows searching recursively through all subfolders by using the directory flattening of ranger.

**Code Changes**
1. Add flags support
2. Use `relative_path` instead of `basename` so patterns like `<subfolder> <filename>` is allowed
3. Deleted default filter option for files not in current working directory (previous codes return `True` for all `fobj` not in current working directory)

**Usage**
You might already have `map <shortcut> console fzf_filter%space` in your `rc.conf`. Feel free to add one more for `map <shortcut> console fzf_filter%space-r%space`.